### PR TITLE
template `withRow` broken with Nim Compiler Version 2.0.8 with {.dirty.} decoration

### DIFF
--- a/sqliteral.nim
+++ b/sqliteral.nim
@@ -451,8 +451,8 @@ template withRow*(db: SQLiteral, statement: enum, params: varargs[DbValue, toDb]
   defer: discard reset(s)
   checkRc(db, bindParams(s, params))
   if step(s) == SQLITE_ROW:
-   var row {.inject.} = s
-   body
+    var row {.inject.} = s
+    body
 
 
 template withRowOr*(db: SQLiteral, statement: enum, params: varargs[DbValue, toDb], row, body1, body2: untyped) =


### PR DESCRIPTION
Remove {.dirty.} decoration which broke the teamplate

```nim
template withRow(db: SQLiteral; statement: enum; params: varargs[Dbvalue, toDb];
                 row, body: untyped) {.dirty.}
```
 With the dirty decoration the error below is experienced 

![Screenshot 2025-02-11 at 1 36 42 PM](https://github.com/user-attachments/assets/b680e16c-a743-42cc-b936-9e648507def8)


